### PR TITLE
fix random

### DIFF
--- a/go-to-random-tab.js
+++ b/go-to-random-tab.js
@@ -17,7 +17,7 @@ function goToRandomTab() {
 
     // Try switching tabs up to three times.
     for (let i = 0; i < 3; i += 1) {
-      let newTabIndex = Math.round(Math.random() * (tabs.length - 1));
+      let newTabIndex = Math.floor(Math.random() * tabs.length);
 
       if (tabs[newTabIndex]) {
         chrome.tabs.update(tabs[newTabIndex].id, { active: true });


### PR DESCRIPTION
A few changes per Mozilla's `Math.random()` documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random#Getting_a_random_integer_between_two_values