### PR TITLE
Add setting to choose between all tabs and current window only

### DIFF
--- a/go-to-random-tab.js
+++ b/go-to-random-tab.js
@@ -6,7 +6,6 @@ const LIMIT_CURRENT_WINDOW = 'limit-to-current-window'
 function goToRandomTab() {
   chrome.storage.sync.get(LIMIT_CURRENT_WINDOW, data => {
     chrome.tabs.query({ active: false, currentWindow: data[LIMIT_CURRENT_WINDOW] }, tabs => {
-      console.log(data, tabs.length)
       // If we need at least one other tabs to switch anywhere.
       if (tabs.length < 1) {
         return;
@@ -55,7 +54,6 @@ function init() {
     chrome.contextMenus.onClicked.addListener(info => {
       if (info.menuItemId == LIMIT_CURRENT_WINDOW) {
         chrome.storage.sync.set({ [LIMIT_CURRENT_WINDOW]: info.checked })
-        chrome.storage.sync.get(null, console.log)
       }
     })
   })

--- a/go-to-random-tab.js
+++ b/go-to-random-tab.js
@@ -1,30 +1,29 @@
 /* global chrome */
 'use strict';
 
-// Filtering options for tabs.query().
-const tabFilter = {
-  // Avoid switching to the current tab.
-  active: false,
-  currentWindow: true,
-};
+const LIMIT_CURRENT_WINDOW = 'limit-to-current-window'
 
 function goToRandomTab() {
-  chrome.tabs.query(tabFilter, function (tabs) {
-    // If we need at least one other tabs to switch anywhere.
-    if (tabs.length < 1) {
-      return;
-    }
-
-    // Try switching tabs up to three times.
-    for (let i = 0; i < 3; i += 1) {
-      let newTabIndex = Math.floor(Math.random() * tabs.length);
-
-      if (tabs[newTabIndex]) {
-        chrome.tabs.update(tabs[newTabIndex].id, { active: true });
-        break;
+  chrome.storage.sync.get(LIMIT_CURRENT_WINDOW, data => {
+    chrome.tabs.query({ active: false, currentWindow: data[LIMIT_CURRENT_WINDOW] }, tabs => {
+      console.log(data, tabs.length)
+      // If we need at least one other tabs to switch anywhere.
+      if (tabs.length < 1) {
+        return;
       }
-    }
-  });
+
+      // Try switching tabs up to three times.
+      for (let i = 0; i < 3; i += 1) {
+        let newTabIndex = Math.floor(Math.random() * tabs.length);
+
+        if (tabs[newTabIndex]) {
+          chrome.windows.update(tabs[newTabIndex].windowId, { focused: true })
+          chrome.tabs.update(tabs[newTabIndex].id, { active: true });
+          break;
+        }
+      }
+    })
+  })
 }
 
 chrome.browserAction.onClicked.addListener(function (tab) {
@@ -36,3 +35,30 @@ chrome.commands.onCommand.addListener(function (command) {
     goToRandomTab();
   }
 });
+
+function init() {
+  chrome.storage.sync.get(LIMIT_CURRENT_WINDOW, data => {
+    let currentWindow = data[LIMIT_CURRENT_WINDOW]
+    if (!(currentWindow == true || currentWindow == false)) { // init
+      chrome.storage.sync.set({ LIMIT_CURRENT_WINDOW: false })
+      currentWindow = false
+    }
+
+    chrome.contextMenus.create({
+      id: LIMIT_CURRENT_WINDOW,
+      title: "Limit to active window",
+      type: 'checkbox',
+      checked: currentWindow,
+      contexts: ['browser_action'],
+    })
+
+    chrome.contextMenus.onClicked.addListener(info => {
+      if (info.menuItemId == LIMIT_CURRENT_WINDOW) {
+        chrome.storage.sync.set({ [LIMIT_CURRENT_WINDOW]: info.checked })
+        chrome.storage.sync.get(null, console.log)
+      }
+    })
+  })
+}
+
+init()

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Go to random tab",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A simple button to go to a random open tab.",
   "homepage_url": "https://github.com/mikl/browser-go-to-random-tab",
   "icons": {
@@ -13,7 +13,7 @@
       "id": "jid1-3vuPf16zAtrlFA@jetpack"
     }
   },
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "contextMenus", "storage"],
   "browser_action": {
     "browser_style": true,
     "default_area": "tabstrip",


### PR DESCRIPTION
Inspired by #5 for setting management, I added a checkbox in the context menu to choose between switching to a random tab in the current window only vs in all windows.

Tested on Firefox.